### PR TITLE
Lock the RuboCop version over `0.49.0`

### DIFF
--- a/dmm-crawler.gemspec
+++ b/dmm-crawler.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'rake'
-  spec.add_development_dependency 'rubocop'
+  spec.add_development_dependency 'rubocop', '< 0.49.0'
   spec.add_development_dependency 'pry'
   spec.add_development_dependency 'rspec'
 end


### PR DESCRIPTION
Close https://github.com/sachin21/dmm-crawler/issues/99