### PR TITLE
Make price integer

### DIFF
--- a/lib/dmm-crawler/attributes.rb
+++ b/lib/dmm-crawler/attributes.rb
@@ -61,9 +61,11 @@ module DMMCrawler
     end
 
     def price
-      @page
-        .search('.m-priceList .priceList__sub.priceList__sub--big')
-        .text.strip.delete('円,')
+      Integer(
+        @page
+          .search('.m-priceList .priceList__sub.priceList__sub--big')
+          .text.strip.delete('円,')
+      )
     end
 
     def author


### PR DESCRIPTION
`get_attributes` method does return the string price but it should be the integer because it is the price.

Close https://github.com/sachin21/dmm-crawler/issues/116