### PR TITLE
Revert "Use HTTPS in all connections"

### DIFF
--- a/lib/dmm-crawler.rb
+++ b/lib/dmm-crawler.rb
@@ -1,7 +1,7 @@
 require 'mechanize'
 
 module DMMCrawler
-  BASE_URL = 'https://www.dmm.co.jp'.freeze
+  BASE_URL = 'http://www.dmm.co.jp'.freeze
 end
 
 require 'dmm-crawler/agent'


### PR DESCRIPTION
Reverts sachin21/dmm-crawler#127

If use the HTTPS, occur the this error `net::ERR_CONNECTION_CLOSED`.