### PR TITLE
Fix a bug where 2019's eroge ranking is not found on FANZA

### DIFF
--- a/lib/dmm-crawler/ranking/adult_game_ranking.rb
+++ b/lib/dmm-crawler/ranking/adult_game_ranking.rb
@@ -45,7 +45,7 @@ module DMMCrawler
         when 'monthly'
           ''
         when 'yearly'
-          "term=first/year=#{Time.now.year}/"
+          "term=all/year=2018"
         end
       end
     end


### PR DESCRIPTION
Close https://github.com/sachin21/dmm-crawler/issues/170